### PR TITLE
96. Unique Binary Search Trees 풀이

### DIFF
--- a/Tree/M-96-Unique Binary Search Trees/JeongYe.js
+++ b/Tree/M-96-Unique Binary Search Trees/JeongYe.js
@@ -1,0 +1,26 @@
+/**
+ * @param {number} n
+ * @return {number}
+ */
+/**
+ * dp[i] = i를 루트로 하는 BST의 개수 
+ * 루트가 1 : dp[0] * dp[n-1] 
+ * 루트가 2 : dp[1] * dp[n-2] 
+ * 루트가 3 : dp[2] * dp[n-3] 
+ * ... 
+ * 루트가 n : dp[n-1] * d[0]
+ */
+ var numTrees = function(n) {
+   
+    let dp = Array(n+1).fill(0); 
+    dp[0] = 1; 
+    dp[1] = 1; 
+    
+    for(let i=2; i<=n; i++) {
+        for(let j=1; j<=i; j++) {
+            dp[i] += dp[j-1] * dp[i-j]; 
+        }
+    } 
+    
+    return dp[n];
+};


### PR DESCRIPTION
처음에 재귀로 풀어보려다가 모든 경우의 수에 대해서 순회하면 오래 걸릴 것 같고 코드도 잘 안짜졌습니다ㅜㅜ 
그래서 다른 풀이 참고해서 dp를 이용해서 풀었습니다. 점화식 도출해내는 과정이 잘 이해가 안가서 오래걸렸네요.. 

---
- dp[i] 는 i가 루트일 때 가질 수 있는 BST의 개수 입니다. 
- 루트가 1 이면 : dp[0] * dp[n-1] 
- 루트가 2 이면 : dp[1] * dp[n-2] ... 
- 위 과정에서 점화식을 도출해보면 `dp[n] = dp[n-1] * dp[0]` 이 됩니다. 

