### PR TITLE
17. Letter Combinations of a Phone Number 풀이

### DIFF
--- a/Greedy/M-17-Letter Combinations of a Phone Number/JeongYe.js
+++ b/Greedy/M-17-Letter Combinations of a Phone Number/JeongYe.js
@@ -16,38 +16,20 @@ var letterCombinations = function (digits) {
     9: ["w", "x", "y", "z"],
   };
 
-  const maxSize = digits.length;
-  let index = 1;
-  let combination = digitMap[digits.charAt(0)];
-  if (digits.length === 1) return combination;
+  let result = [];
+  function backtrack(str, index) {
+    if (str.length === digits.length) {
+      result.push(str);
+      return;
+    }
 
-  //파라미터로 넘어온 배열에 현재 인덱스의 알파벳 목록과 1:1 매핑 한다.
-  function recursion() {
-    if (index === maxSize) return;
-
-    const digit = digits.charAt(index);
-    const letters = digitMap[digit];
-
-    let temp = [];
-    letters.forEach((letter) => {
-      combination.forEach((prev) => {
-        temp.push(prev + letter);
-      });
-    });
-
-    index++;
-    combination = temp;
-
-    recursion();
+    //str을 고정 시키고 문자열을 이어 붙인다.
+    for (let letter of digitMap[digits[index]]) {
+      backtrack(str + letter, index + 1);
+    }
   }
 
-  recursion();
-  return combination;
+  backtrack("", 0);
+
+  return result;
 };
-
-//test
-const digits = "9";
-//   const digits = "";
-// const digits = "2";
-
-console.log(letterCombinations(digits));

--- a/Greedy/M-17-Letter Combinations of a Phone Number/JeongYe.js
+++ b/Greedy/M-17-Letter Combinations of a Phone Number/JeongYe.js
@@ -1,0 +1,53 @@
+/**
+ * @param {string} digits
+ * @return {string[]}
+ */
+var letterCombinations = function (digits) {
+  if (!digits.length) return [];
+
+  const digitMap = {
+    2: ["a", "b", "c"],
+    3: ["d", "e", "f"],
+    4: ["g", "h", "i"],
+    5: ["j", "k", "l"],
+    6: ["m", "n", "o"],
+    7: ["p", "q", "r", "s"],
+    8: ["t", "u", "v"],
+    9: ["w", "x", "y", "z"],
+  };
+
+  const maxSize = digits.length;
+  let index = 1;
+  let combination = digitMap[digits.charAt(0)];
+  if (digits.length === 1) return combination;
+
+  //파라미터로 넘어온 배열에 현재 인덱스의 알파벳 목록과 1:1 매핑 한다.
+  function recursion() {
+    if (index === maxSize) return;
+
+    const digit = digits.charAt(index);
+    const letters = digitMap[digit];
+
+    let temp = [];
+    letters.forEach((letter) => {
+      combination.forEach((prev) => {
+        temp.push(prev + letter);
+      });
+    });
+
+    index++;
+    combination = temp;
+
+    recursion();
+  }
+
+  recursion();
+  return combination;
+};
+
+//test
+const digits = "9";
+//   const digits = "";
+// const digits = "2";
+
+console.log(letterCombinations(digits));


### PR DESCRIPTION
- 재귀를 이용해서 풀었습니다. 

- 각 번호와 매핑되는 알파벳 배열을 담은 map을 생성한다. 
- 번호별 알파벳 조합을 담을 combination 배열을 생성한다. 
- digits의 각 자릿수를 가리키는 index 변수를 이용해서, 현재 자리수와 매핑되는 알파벳 배열을 가져옵니다. 
`예) "2" -> [a,b,c]` 
- 현재 자릿수의 알파벳 배열을 반복문을 돌면서 combinaton의 각 배열 요소의 문자열과 연결합니다. 
- 자릿수를 가리키는 index 변수가 입력받은 문자열 길이와 같아지면 재귀에서 빠져옵니다. 

--- 
첫 번째 풀이가 만족스럽지 못해서 다른 풀이 참고해서 다시 풀었습니다! 
- 시작 문자열, 번호 자릿수 index를 받는 재귀 함수를 구현했습니다. 
- 시작 문자열은 고정 시키고, 현재 번호 자릿수와 맵핑되는 알파벳 배열을 문자열에 이어 붙입니다. 
- 문자열의 길이가 digits 길이와 같아지면 result 배열에 넣고, 재귀를 빠져나옵니다. 

