### PR TITLE
[JeongYe] 687. Longest Univalue Path 풀이

### DIFF
--- a/601~700/M-687-Longest Univalue Path/JeongYe.js
+++ b/601~700/M-687-Longest Univalue Path/JeongYe.js
@@ -1,0 +1,35 @@
+/**
+ * Definition for a binary tree node.
+ * function TreeNode(val, left, right) {
+ *     this.val = (val===undefined ? 0 : val)
+ *     this.left = (left===undefined ? null : left)
+ *     this.right = (right===undefined ? null : right)
+ * }
+ */
+/**
+ * @param {TreeNode} root
+ * @return {number}
+ */
+var longestUnivaluePath = function (root) {
+  let count = 0;
+
+  function dfs(rootVal, current) {
+    if (!current) return 0;
+
+    //왼쪽, 오른쪽 노드 자식을 각각 탐색하면서
+    //동일한 경로로 이루어진 노드의 개수를 구한다.
+    const leftCount = dfs(current.val, current.left);
+    const rightCount = dfs(current.val, current.right);
+
+    //경로의 최대 값을 갱신한다.
+    count = Math.max(count, leftCount + rightCount);
+
+    //루트 값이랑 현재 노드 값이 동일하다면 경로를 +1 연장
+    //일치하지 않는다면 경로를 0으로 초기화 한다.
+    return rootVal === current.val ? Math.max(leftCount, rightCount) + 1 : 0;
+  }
+
+  if (root) dfs(root.val, root);
+
+  return count;
+};


### PR DESCRIPTION
- 재귀를 이용해서 트리의 왼쪽, 오른쪽 자식을 탐색합니다. 
- 왼쪽 트리 경로 + 오른쪽 트리 경로 값으로 최대 경로 값을 갱신합니다. 
- 루트 값과 현재 노드의 값이 동일하다면, 왼쪽 경로와 오른쪽 경로 중 최대 값에 + 1을 더한 값을 반환합니다. 

처음에 경로의 정의를 잘못 이해해서 같은 값으로 연결되어있는 모든 노드를 하나의 경로로 착각했습니다..! 
그래서 dfs로 트리를 탐색하면서 루트와 현재 노드가 동일하면 카운트를 +1씩 해줘서 최대 값을 갱신하는 방식으로 풀이했는데 이 부분에서 많이 헤맸네요ㅠㅠ